### PR TITLE
Adds option to keep absolute paths

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -107,6 +107,17 @@ To disable this behavior, add this to `test/mocha.opts`:
 
 <br>
 
+## Showing absolute paths
+
+By default, mocha-clean removes the current working directory from the beginning
+of paths. To disable this behavior, add this to `test/mocha.opts`:
+
+```js
+--require mocha-clean/absolute_paths
+```
+
+<br>
+
 ## Related discussions
 
 There was talk in 2012 to bring this feature to mocha itself (see [mocha#545]),

--- a/absolute_paths.js
+++ b/absolute_paths.js
@@ -1,0 +1,2 @@
+process.env.SHOW_ABSOLUTE_PATHS = true;
+require('./index');

--- a/index.js
+++ b/index.js
@@ -59,7 +59,8 @@ function __mocha_internal__cleanError (e) {
       return list;
 
     // Clean up cwd.
-    line = line.replace(cwd, '');
+    if (!env().SHOW_ABSOLUTE_PATHS)
+      line = line.replace(cwd, '');
 
     // experimental: show errors in a format
     // like "example/foo.js:10:19: at functionName"


### PR DESCRIPTION
This pull request adds an option to keep absolute paths in the stack. This can be handy for tooling and IDEs.
